### PR TITLE
refactor remove gulp-util dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "plugin-error": "^0.1.2",
     "readable-stream": "^2.0.4",
     "replace-ext": "^1.0.0",
-    "ttf2eot": "^2.0.0",
-    "vinyl": "^2.1.0"
+    "ttf2eot": "^2.0.0"
   },
   "keywords": [
     "gulpplugin",
@@ -51,6 +50,7 @@
     "istanbul": "^0.4.0",
     "mocha": "^3.4.2",
     "mocha-lcov-reporter": "^1.0.0",
-    "streamtest": "^1.2.1"
+    "streamtest": "^1.2.1",
+    "vinyl": "^2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
   },
   "dependencies": {
     "bufferstreams": "^1.1.0",
-    "gulp-util": "^3.0.7",
+    "plugin-error": "^0.1.2",
     "readable-stream": "^2.0.4",
-    "ttf2eot": "^2.0.0"
+    "replace-ext": "^1.0.0",
+    "ttf2eot": "^2.0.0",
+    "vinyl": "^2.1.0"
   },
   "keywords": [
     "gulpplugin",
@@ -43,6 +45,7 @@
     "converter"
   ],
   "devDependencies": {
+    "cloneable-readable": "^1.0.0",
     "coveralls": "^2.11.4",
     "gulp": "^3.9.0",
     "istanbul": "^0.4.0",

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,8 @@
 
 var path = require('path');
 var Stream = require('readable-stream');
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
+var replaceExtension = require('replace-ext');
 var BufferStreams = require('bufferstreams');
 var ttf2eot = require('ttf2eot');
 
@@ -15,7 +16,7 @@ function ttf2eotTransform() {
 
     // Handle any error
     if(err) {
-      return cb(new gutil.PluginError(PLUGIN_NAME, err, { showStack: true }));
+      return cb(new PluginError(PLUGIN_NAME, err, { showStack: true }));
     }
 
     // Use the buffered content
@@ -23,7 +24,7 @@ function ttf2eotTransform() {
       buf = new Buffer(ttf2eot(new Uint8Array(buf)).buffer);
       return cb(null, buf);
     } catch(err2) {
-      return cb(new gutil.PluginError(PLUGIN_NAME, err2, { showStack: true }));
+      return cb(new PluginError(PLUGIN_NAME, err2, { showStack: true }));
     }
 
   };
@@ -68,7 +69,7 @@ function ttf2eotGulp(options) {
       }
     }
 
-    file.path = gutil.replaceExtension(file.path, '.eot');
+    file.path = replaceExtension(file.path, '.eot');
 
     // Buffers
     if(file.isBuffer()) {
@@ -77,7 +78,7 @@ function ttf2eotGulp(options) {
           new Uint8Array(file.contents)
         ).buffer);
       } catch(err) {
-        stream.emit('error', new gutil.PluginError(PLUGIN_NAME, err, {
+        stream.emit('error', new PluginError(PLUGIN_NAME, err, {
           showStack: true,
         }));
       }

--- a/tests/index.mocha.js
+++ b/tests/index.mocha.js
@@ -6,7 +6,6 @@ var gulp = require('gulp');
 var Vinyl = require('vinyl');
 var Cloneable = require('cloneable-readable');
 var Stream = require('stream');
-
 var fs = require('fs');
 var path = require('path');
 
@@ -163,7 +162,7 @@ describe('gulp-ttf2eot conversion', function() {
 
           StreamTest[version].fromObjects([new Vinyl({
             path: 'bibabelula.foo',
-            contents: new Stream.PassThrough()
+            contents: new Stream.PassThrough(),
           })])
           .pipe(ttf2eot())
           .pipe(StreamTest[version].toObjects(function(err, objs) {

--- a/tests/index.mocha.js
+++ b/tests/index.mocha.js
@@ -3,8 +3,10 @@
 'use strict';
 
 var gulp = require('gulp');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
+var Cloneable = require('cloneable-readable');
 var Stream = require('stream');
+
 var fs = require('fs');
 var path = require('path');
 
@@ -26,7 +28,7 @@ describe('gulp-ttf2eot conversion', function() {
 
         it('should let null files pass through', function(done) {
 
-          StreamTest[version].fromObjects([new gutil.File({
+          StreamTest[version].fromObjects([new Vinyl({
             path: 'bibabelula.foo',
             contents: null,
           })])
@@ -88,7 +90,7 @@ describe('gulp-ttf2eot conversion', function() {
 
         it('should let non-ttf files pass through', function(done) {
 
-          StreamTest[version].fromObjects([new gutil.File({
+          StreamTest[version].fromObjects([new Vinyl({
             path: 'bibabelula.foo',
             contents: new Buffer('ohyeah'),
           })])
@@ -159,9 +161,9 @@ describe('gulp-ttf2eot conversion', function() {
 
         it('should let non-ttf files pass through', function(done) {
 
-          StreamTest[version].fromObjects([new gutil.File({
+          StreamTest[version].fromObjects([new Vinyl({
             path: 'bibabelula.foo',
-            contents: new Stream.PassThrough(),
+            contents: new Stream.PassThrough()
           })])
           .pipe(ttf2eot())
           .pipe(StreamTest[version].toObjects(function(err, objs) {
@@ -170,7 +172,8 @@ describe('gulp-ttf2eot conversion', function() {
             }
             assert.equal(objs.length, 1);
             assert.equal(objs[0].path, 'bibabelula.foo');
-            assert(objs[0].contents instanceof Stream.PassThrough);
+            assert(Cloneable.isCloneable(objs[0].contents));
+            assert(objs[0].contents._original instanceof Stream.PassThrough);
             done();
           }));
 


### PR DESCRIPTION
Hi,

Since gulp-util has been deprecated, this PR replaces gulp-util with alternative individual modules. https://github.com/gulpjs/gulp-util